### PR TITLE
Fix possible deserialization failures

### DIFF
--- a/src/ChatGPT.Net/ChatGPTUnofficial.cs
+++ b/src/ChatGPT.Net/ChatGPTUnofficial.cs
@@ -273,6 +273,9 @@ public class ChatGptUnofficial
         await foreach (var data in StreamCompletion(stream))
         {
             var dataJson = data;
+            //Ignore ping event
+            if (dataJson.StartsWith("event: "))
+                continue;
             //Trim start
             if (dataJson.StartsWith("data: "))
                 dataJson = dataJson[6..];
@@ -280,11 +283,15 @@ public class ChatGptUnofficial
             if (dataJson.ToLower() == "[done]")
                 continue;
             //Try Deserialize
-            var replyNew = JsonConvert.DeserializeObject<ChatGptUnofficialMessageResponse>(dataJson);
-            if (replyNew == null)
-                continue;
-            reply = replyNew;
-            callback?.Invoke(reply);
+            try
+            {
+                var replyNew = JsonConvert.DeserializeObject<ChatGptUnofficialMessageResponse>(dataJson);
+                if (replyNew == null)
+                    continue;
+                reply = replyNew;
+                callback?.Invoke(reply);
+            }
+            catch { }
         }
 
         return reply ?? new ChatGptUnofficialMessageResponse();


### PR DESCRIPTION
**Issue**
When calling `ChatGptUnofficial.AskStream`, an exception may be thrown if the completion time exceeds 15 seconds.
```
Newtonsoft.Json.JsonReaderException: Input string '2023-05-12' is not a valid number. Path '', line 1, position 10.
   at Newtonsoft.Json.JsonTextReader.ParseReadNumber(ReadType readType, Char firstChar, Int32 initialPosition)
   at Newtonsoft.Json.JsonTextReader.ParseValue()
   at Newtonsoft.Json.JsonReader.ReadForType(JsonContract contract, Boolean hasConverter)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
   at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonConvert.DeserializeObject(String value, Type type, JsonSerializerSettings settings)
   at ChatGPT.Net.ChatGptUnofficial.SendMessage(String message, String messageId, String parentMessageId, String conversationId, String model, Action`1 callback) in E:\Study\Mirai-console\livebot\source\ChatGPT.Net\ChatGPTUnofficial.cs:line 292
```

**Reason**
The conversation API will return a 'ping event' and a timestamp every 15 seconds. The format is as follows.
They cannot be deserialized into JSON, resulting in exceptions.
```
event: ping
data: 2023-05-12 06:31:06.341774
```

**Modification**

1. Ignore the event messages in response.
2. Catch exceptions in the deserialization.