### PR TITLE
Adding ChatGPT responses to conversation so context is maintained.

### DIFF
--- a/src/ChatGPT.Net/ChatGPT.cs
+++ b/src/ChatGPT.Net/ChatGPT.cs
@@ -154,7 +154,15 @@ public class ChatGpt
         
         conversation.Updated = DateTime.Now;
 
-        return reply.Choices.FirstOrDefault()?.Message.Content ?? "";
+        var response = reply.Choices.FirstOrDefault()?.Message.Content ?? "";
+
+        conversation.Messages.Add(new ChatGptMessage
+        {
+            Role = "assistant",
+            Content = response
+        });
+
+        return response;
     }
 
     public async Task<string> AskStream(Action<string> callback, string prompt, string? conversationId = null)


### PR DESCRIPTION
We were seeing strange results from chatgpt and after reviewing the documention found that the api expects both sides of the conversation to maintain context.