### PR TITLE
Issue #46 - added sample code to demonstrate how to set system messag…

### DIFF
--- a/README.md.bak
+++ b/README.md.bak
@@ -91,10 +91,6 @@ Console.WriteLine(response);
 await bot.AskStream(response => {
     Console.WriteLine(response);
 }, "What is the weather like today?", "conversation name");
-
-// Set a system message
-bot.SetConversationSystemMessage("conversation name", "You are a helpful assistant that provides clear and concise answers to questions.");
-
 ```
 
 ### ChatGPT Unofficial API


### PR DESCRIPTION
Issue #46 - added sample code to demonstrate how to set system message for the conversation.
The implementation was already there, but in [issue 46](https://github.com/PawanOsman/ChatGPT.Net/issues/46), user couldn't guess how to set system message as it wasn't documented in sample code.